### PR TITLE
Add `ruff` and comply with it.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,9 @@ repos:
     hooks:
       - id: check-merge-conflict
         args: [--assume-in-merge]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.4
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]

--- a/doc/changelog_entries/12.feature.rst
+++ b/doc/changelog_entries/12.feature.rst
@@ -1,0 +1,1 @@
+`ruff` has been configured for the project via `pre-commit`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 dependencies = []
 readme = "README.md"
-requires-python = ">= 3.11"
+requires-python = ">= 3.11" # Sync with ruff target-version
 license = { text = "MIT" }
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -78,3 +78,22 @@ issue_format = "https://github.com/nathanjmcdougall/suiteas/issues/{issue}"
 directory = "feature"
 name = "Features"
 showcontent = true
+
+[tool.ruff]
+src = ["src"]
+select = ["ALL"]
+ignore = [
+    "S101", # Use of assert is controversial but in any case is useful with pytest
+    "D202", # This is controversial, it is useful to have a blank line after a docstring
+    "D203", # This is controversial, no need to have a blank line before a docstring
+    "D213", # This conflicts with D212 and violates PEP 257
+    "D406", # This rule is for non-Google style docstrings
+    "D407", # This rule is for non-Google style docstrings
+    "D408", # This rule is for non-Google style docstrings
+    "D409", # This rule is for non-Google style docstrings
+]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.pydocstyle]
+convention = "google"

--- a/src/suiteas/__init__.py
+++ b/src/suiteas/__init__.py
@@ -1,2 +1,8 @@
-def hello():
+"""The suiteas package."""
+
+def hello() -> None:
+    """Return a greeting.
+
+    This is a placeholder function until the package has content.
+    """
     return "Hello from suiteas!"


### PR DESCRIPTION
Signed-off-by: Nathan McDougall <nathan.j.mcdougall@gmail.com>